### PR TITLE
3F2 multiplexer grew by 1 bit on FW 2020.48.10

### DIFF
--- a/Model3CAN.dbc
+++ b/Model3CAN.dbc
@@ -2896,7 +2896,7 @@ BO_ 978 ID3D2TotalChargeDischarge: 8 VehicleBus
  SG_ TotalChargeKWh3D2 : 32|32@1+ (0.001,0) [0|4294967.295] "kWh"  Receiver
 
 BO_ 1010 ID3F2BMSCounters: 8 VehicleBus
- SG_ BMSCountersIndex3F2 M : 0|3@1+ (1,0) [0|0] ""  Receiver
+ SG_ BMSCountersIndex3F2 M : 0|4@1+ (1,0) [0|0] ""  Receiver
  SG_ BMStotalACcharge3F2 m0 : 8|32@1+ (0.001,0) [0|4294967.295] "KWh"  Receiver
  SG_ BMStotalDCcharge3F2 m1 : 8|32@1+ (0.001,0) [0|4294967.295] "KWh"  Receiver
  SG_ BMStotalRegenCharge3F2 m2 : 8|32@1+ (0.001,0) [0|4294967.295] "KWh"  Receiver


### PR DESCRIPTION
This probably means there is a new page with info in there, but for now, this fixes Scan My Tesla so the values aren't jumping around.