### PR TITLE
Fix GPS degrees

### DIFF
--- a/Model3CAN.dbc
+++ b/Model3CAN.dbc
@@ -2348,8 +2348,8 @@ BO_ 616 ID268SystemPower: 5 VehicleBus
 
 BO_ 79 ID04FGPSLatLong: 8 ChassisBus
  SG_ GPSAccuracy04F : 57|7@1+ (0.2,0) [0|25.2] "m"  Receiver
- SG_ GPSLongitude04F : 28|28@1- (1E-006,0) [-134.218|134.218] "Deg"  Receiver
- SG_ GPSLatitude04F : 0|28@1- (1E-006,0) [-134.218|134.218] "Deg"  Receiver
+ SG_ GPSLongitude04F : 28|28@1+ (1E-006,0) [0|365] "Deg"  Receiver
+ SG_ GPSLatitude04F : 0|28@1- (1E-006,0) [-90|90] "Deg"  Receiver
 
 BO_ 978 ID3D2TotalChargeDischarge: 8 VehicleBus
  SG_ TotalDischargeKWh3D2 : 0|32@1+ (0.001,0) [0|4294970] "kWh"  Receiver

--- a/Model3CAN.dbc
+++ b/Model3CAN.dbc
@@ -2348,7 +2348,7 @@ BO_ 616 ID268SystemPower: 5 VehicleBus
 
 BO_ 79 ID04FGPSLatLong: 8 ChassisBus
  SG_ GPSAccuracy04F : 57|7@1+ (0.2,0) [0|25.2] "m"  Receiver
- SG_ GPSLongitude04F : 28|28@1+ (1E-006,0) [0|365] "Deg"  Receiver
+ SG_ GPSLongitude04F : 28|28@1+ (1E-006,0) [0|360] "Deg"  Receiver
  SG_ GPSLatitude04F : 0|28@1- (1E-006,0) [-90|90] "Deg"  Receiver
 
 BO_ 978 ID3D2TotalChargeDischarge: 8 VehicleBus


### PR DESCRIPTION
The `GPSLongitude04F` value was completely wrong coming out of my 2021 Model 3, so after some experimentation I figured out the value is not signed. Rather than being a value east or west of the prime meridian, its an unsigned value going east.

I also updated the min max values of `GPSLatitude04F` since that can only be a maximum of 90 degrees above or below the equator.

I live in the eastern hemisphere, so I have not been able to test this from a western hemisphere perspective.